### PR TITLE
Local RT Setup: Temporarily use version 7.84.17

### DIFF
--- a/actions/install-local-artifactory/action.yml
+++ b/actions/install-local-artifactory/action.yml
@@ -14,6 +14,7 @@ runs:
     - name: Install Local Artifactory
       run: |
         go install github.com/jfrog/jfrog-testing-infra/local-rt-setup@latest
+        # Temporarily use version 7.84.17 due to an issue with the automatic token generation mechanism in 7.90
         ~/go/bin/local-rt-setup --rt-version 7.84.17
       shell: bash
       env:

--- a/actions/install-local-artifactory/action.yml
+++ b/actions/install-local-artifactory/action.yml
@@ -14,7 +14,7 @@ runs:
     - name: Install Local Artifactory
       run: |
         go install github.com/jfrog/jfrog-testing-infra/local-rt-setup@latest
-        ~/go/bin/local-rt-setup
+        ~/go/bin/local-rt-setup --rt-version 7.84.17
       shell: bash
       env:
         RTLIC: ${{ inputs.RTLIC }}


### PR DESCRIPTION
There is an issue with the [automatic token generation](https://jfrog.com/help/r/jfrog-installation-setup-documentation/create-an-automatic-admin-token) mechanism in Artifactory 7.90. To handle this, temporarily set the version to 7.84.17.

> 2024/07/25 13:50:27 Waiting for successful connection with Artifactory...
...
2024/07/25 13:55:11 JFAC token file "/home/runner/jfrog_home/artifactory/var/etc/access/keys/token.json" does not exist.
2024/07/25 13:55:11 Artifactory response: 404. Trying again in 10 seconds.
2024/07/25 13:55:21 JFAC token file "/home/runner/jfrog_home/artifactory/var/etc/access/keys/token.json" does not exist.
2024/07/25 13:55:21 Artifactory response: 404. Trying again in 10 seconds.
2024/07/25 13:55:31 JFAC token file "/home/runner/jfrog_home/artifactory/var/etc/access/keys/token.json" does not exist.
2024/07/25 13:55:31 Artifactory response: 404. Trying again in 10 seconds.
2024/07/25 13:55:31 could not connect to Artifactory