### PR TITLE
Removed exportloopref check from golangcilint

### DIFF
--- a/actions/golangci-lint/action.yml
+++ b/actions/golangci-lint/action.yml
@@ -13,4 +13,4 @@ runs:
       with:
         skip-cache: true
         args: |
-          --timeout 5m --enable errcheck,gosimple,ineffassign,staticcheck,typecheck,unused,gocritic,asasalint,asciicheck,errchkjson,exportloopref,forcetypeassert,makezero,nilerr,unparam,unconvert,wastedassign,usestdlibvars --disable govet
+          --timeout 5m --enable errcheck,gosimple,ineffassign,staticcheck,typecheck,unused,gocritic,asasalint,asciicheck,errchkjson,forcetypeassert,makezero,nilerr,unparam,unconvert,wastedassign,usestdlibvars --disable govet


### PR DESCRIPTION
- golangci-lint with latest version 1.64.2 the linter type `exportloopref` is inactivated and resulting in exit 1 and all static checks failing across org.
- This PR removes the `exportloopref` lint to fix above issue.
- The linter `exportloopref` is already deprecated since `1.60.2`
<img width="1229" alt="image" src="https://github.com/user-attachments/assets/4969fff0-8671-4816-bf3b-1f8d8e483887" />
