### PR TITLE
Fix to collect custom version of artifactory instead of [RELEASE] for installing local-rt-setup

### DIFF
--- a/actions/install-local-artifactory/action.yml
+++ b/actions/install-local-artifactory/action.yml
@@ -17,12 +17,11 @@ runs:
     - name: Install Local Artifactory
       run: |
         go install github.com/jfrog/jfrog-testing-infra/local-rt-setup@main
-        if [ -n "${{ env.VERSION }}" ]; then
-          ~/go/bin/local-rt-setup --rt-version "$VERSION"
+        if [ -n "${VERSION}" ]; then
+          ~/go/bin/local-rt-setup --rt-version "${VERSION}"
         else
           ~/go/bin/local-rt-setup
         fi
-      shell: bash
       env:
         RTLIC: ${{ inputs.RTLIC }}
         JFROG_HOME: ${{ inputs.JFROG_HOME }}

--- a/actions/install-local-artifactory/action.yml
+++ b/actions/install-local-artifactory/action.yml
@@ -22,6 +22,7 @@ runs:
         else
           ~/go/bin/local-rt-setup
         fi
+      shell: bash
       env:
         RTLIC: ${{ inputs.RTLIC }}
         JFROG_HOME: ${{ inputs.JFROG_HOME }}


### PR DESCRIPTION
Bug: Version set as input to `Install local Artifactory` is not getting honored

```
- name: Install local Artifactory
        uses: jfrog/.github/actions/install-local-artifactory@main
        with:
          RTLIC: ${{ secrets.RTLIC }}
          VERSION: 7.103.X
```

Fix: Instead of using ${{ env.VERSION }} use ${VERSION} to check if version is set.