### PR TITLE
Use latest `jfrog-testing-infra`

### DIFF
--- a/actions/install-local-artifactory/action.yml
+++ b/actions/install-local-artifactory/action.yml
@@ -16,7 +16,7 @@ runs:
   steps:
     - name: Install Local Artifactory
       run: |
-        go install github.com/jfrog/jfrog-testing-infra/local-rt-setup@main
+        go install github.com/jfrog/jfrog-testing-infra/local-rt-setup@latest
         if [ -n "${VERSION}" ]; then
           ~/go/bin/local-rt-setup --rt-version "${VERSION}"
         else


### PR DESCRIPTION
Makes sure we are using the latest commit in jfrog-test-infra
leaving it as `@main` doesn't necessarily get's updated.