### PR TITLE
Added body close check linter

### DIFF
--- a/actions/golangci-lint/action.yml
+++ b/actions/golangci-lint/action.yml
@@ -13,4 +13,4 @@ runs:
       with:
         skip-cache: true
         args: |
-          --timeout 5m --enable errcheck,ineffassign,staticcheck,unused,gocritic,asasalint,asciicheck,errchkjson,forcetypeassert,makezero,nilerr,unparam,unconvert,wastedassign,usestdlibvars --disable govet
+          --timeout 5m --enable errcheck,ineffassign,staticcheck,unused,gocritic,asasalint,asciicheck,errchkjson,forcetypeassert,makezero,nilerr,unparam,unconvert,wastedassign,bodyclose,usestdlibvars --disable govet


### PR DESCRIPTION
- Added linter bodyClose to make sure HTTP response body is closed successfully.
- This is added as a safety measure and keep code hygiene once this [PR](https://github.com/jfrog/jfrog-client-go/pull/1180/files) is merged.