### PR TITLE
fix: Use setup-go built-in caching for correct GOMODCACHE detection

### DIFF
--- a/actions/install-go-with-cache/action.yml
+++ b/actions/install-go-with-cache/action.yml
@@ -1,5 +1,5 @@
-name: "Setup and Cache Go and Configure Private in needed"
-description: "Setup and Cache Go 1.23 and Configure Private in needed"
+name: "Setup and Cache Go and Configure Private if needed"
+description: "Setup and Cache Go 1.25 with automatic GOMODCACHE detection"
 inputs:
   gh_token:
     description: "GitHub Personal Access Token"
@@ -7,19 +7,24 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Go Cache
-      uses: actions/cache@v4
-      with:
-        path: ~/go/pkg/mod
-        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-        restore-keys: |
-          ${{ runner.os }}-go-
-
     - name: Setup Go
       uses: actions/setup-go@v5
       with:
         go-version: 1.25
         cache: false
+
+    - name: Detect GOMODCACHE path
+      id: go-cache-paths
+      shell: bash
+      run: echo "gomodcache=$(go env GOMODCACHE)" >> $GITHUB_OUTPUT
+
+    - name: Go Cache
+      uses: actions/cache@v4
+      with:
+        path: ${{ steps.go-cache-paths.outputs.gomodcache }}
+        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          ${{ runner.os }}-go-
 
     - name: Setup Git Private Module
       if: ${{ inputs.gh_token != '' }}


### PR DESCRIPTION
## Problem

The manual cache step used a hardcoded path `~/go/pkg/mod` which doesn't work in container environments where `GOMODCACHE` may be set to a different path.

**Example:** In `automation_env` containers:
- `HOME=/github/home` → `~/go/pkg/mod` = `/github/home/go/pkg/mod`
- But `GOMODCACHE=/go/pkg/mod`

These are different paths, so the cache is restored to the wrong location and Go re-downloads all dependencies on every CI run (~40 seconds wasted per build).

## Solution

Detect `GOMODCACHE` path using `go env GOMODCACHE`:

1. Run `setup-go` first (so Go is available)
2. Detect path with `go env GOMODCACHE`
3. Use detected path for cache

This works in any environment (standard runners, containers, etc.).

## Changes

- Reorder: `setup-go` runs before cache (required to run `go env`)
- Add "Detect GOMODCACHE path" step
- Cache uses `${{ steps.go-cache-paths.outputs.gomodcache }}` instead of hardcoded `~/go/pkg/mod`
- Fix typo: "in needed" → "if needed"
- Update Go version in description: 1.23 → 1.25

## Testing

Identified while analyzing CI logs for `jfrog/fly-service` which uses a custom container with `GOMODCACHE=/go/pkg/mod`.