### PR TITLE
Fix cache warning by ensuring GOMODCACHE directory exists

### DIFF
--- a/actions/install-go-with-cache/action.yml
+++ b/actions/install-go-with-cache/action.yml
@@ -16,7 +16,15 @@ runs:
     - name: Detect GOMODCACHE path
       id: go-cache-paths
       shell: bash
-      run: echo "gomodcache=$(go env GOMODCACHE)" >> $GITHUB_OUTPUT
+      run: |
+        GOMODCACHE=$(go env GOMODCACHE)
+        # Fallback to default location if empty
+        if [ -z "$GOMODCACHE" ]; then
+          GOMODCACHE="$HOME/go/pkg/mod"
+        fi
+        # Ensure directory exists to prevent cache action warning
+        mkdir -p "$GOMODCACHE"
+        echo "gomodcache=$GOMODCACHE" >> $GITHUB_OUTPUT
 
     - name: Go Cache
       uses: actions/cache@v4


### PR DESCRIPTION
## Summary

Fixes the `[warning]Input required and not supplied: path` warning that occurs during post-job cleanup of the Go cache action.

## Problem

The `actions/cache@v4` action requires the cache path to exist. When:
1. `go env GOMODCACHE` returns an empty string, or
2. The GOMODCACHE directory doesn't exist yet (e.g., on cache hit when no modules are downloaded)

The cache action produces a warning during post-job cleanup.

## Solution

1. Added fallback to `~/go/pkg/mod` (Go's default) if `GOMODCACHE` is empty
2. Created the directory with `mkdir -p` before the cache action runs

## Changes

```yaml
- name: Detect GOMODCACHE path
  id: go-cache-paths
  shell: bash
  run: |
    GOMODCACHE=$(go env GOMODCACHE)
    # Fallback to default location if empty
    if [ -z "$GOMODCACHE" ]; then
      GOMODCACHE="$HOME/go/pkg/mod"
    fi
    # Ensure directory exists to prevent cache action warning
    mkdir -p "$GOMODCACHE"
    echo "gomodcache=$GOMODCACHE" >> $GITHUB_OUTPUT
```

## Testing

This change is backwards compatible and only adds defensive checks. The cache behavior remains the same.

Made with [Cursor](https://cursor.com)