### PR TITLE
Add runner.arch to Go cache keys to prevent cross-arch conflicts

### DIFF
--- a/actions/install-go-with-cache/action.yml
+++ b/actions/install-go-with-cache/action.yml
@@ -37,19 +37,21 @@ runs:
         mkdir -p "$GOBIN"
         echo "path=$GOBIN" >> $GITHUB_OUTPUT
 
-    - name: Go Cache
+    - name: Go Modules Cache
       uses: actions/cache@v4
       with:
         path: ${{ steps.go-cache-paths.outputs.gomodcache }}
-        key: ${{ runner.os }}-${{ runner.arch }}-go-${{ hashFiles('**/go.sum') }}
+        key: go-mod-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/go.sum') }}
         restore-keys: |
-          ${{ runner.os }}-${{ runner.arch }}-go-
+          go-mod-${{ runner.os }}-${{ runner.arch }}-
 
     - name: Go Tools Cache
       uses: actions/cache@v4
       with:
         path: ${{ steps.go-bin-path.outputs.path }}
-        key: ${{ runner.os }}-${{ runner.arch }}-gotools
+        key: go-tools-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/Makefile') }}
+        restore-keys: |
+          go-tools-${{ runner.os }}-${{ runner.arch }}-
 
     - name: Setup Git Private Module
       if: ${{ inputs.gh_token != '' }}

--- a/actions/install-go-with-cache/action.yml
+++ b/actions/install-go-with-cache/action.yml
@@ -1,5 +1,5 @@
 name: "Setup and Cache Go and Configure Private if needed"
-description: "Setup and Cache Go 1.25 with automatic GOMODCACHE detection"
+description: "Setup Go 1.25 with architecture-specific caching for modules and tools"
 inputs:
   gh_token:
     description: "GitHub Personal Access Token"

--- a/actions/install-go-with-cache/action.yml
+++ b/actions/install-go-with-cache/action.yml
@@ -41,15 +41,15 @@ runs:
       uses: actions/cache@v4
       with:
         path: ${{ steps.go-cache-paths.outputs.gomodcache }}
-        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+        key: ${{ runner.os }}-${{ runner.arch }}-go-${{ hashFiles('**/go.sum') }}
         restore-keys: |
-          ${{ runner.os }}-go-
+          ${{ runner.os }}-${{ runner.arch }}-go-
 
     - name: Go Tools Cache
       uses: actions/cache@v4
       with:
         path: ${{ steps.go-bin-path.outputs.path }}
-        key: ${{ runner.os }}-gotools
+        key: ${{ runner.os }}-${{ runner.arch }}-gotools
 
     - name: Setup Git Private Module
       if: ${{ inputs.gh_token != '' }}


### PR DESCRIPTION
## Summary
- Added `${{ runner.arch }}` to Go module cache key
- Added `${{ runner.arch }}` to Go tools cache key

## Problem
When amd64 and arm64 runners share the same cache key (`Linux-go-...`), the cache extraction fails with "File exists" errors on self-hosted runners that have persistent storage.

## Solution
Include architecture in cache keys:
- Before: `Linux-go-<hash>`
- After: `Linux-ARM64-go-<hash>` or `Linux-X64-go-<hash>`

This ensures each architecture has its own cache.

Made with [Cursor](https://cursor.com)