### PR TITLE
Add github.job to cache keys to prevent cross-job conflicts

### DIFF
--- a/actions/install-go-with-cache/action.yml
+++ b/actions/install-go-with-cache/action.yml
@@ -37,21 +37,24 @@ runs:
         mkdir -p "$GOBIN"
         echo "path=$GOBIN" >> $GITHUB_OUTPUT
 
+    # Cache keys include github.job to prevent conflicts between jobs that
+    # download different subsets of modules (e.g., a lint job vs a build job).
+    # This ensures each job maintains its own cache without polluting others.
     - name: Go Modules Cache
       uses: actions/cache@v4
       with:
         path: ${{ steps.go-cache-paths.outputs.gomodcache }}
-        key: go-mod-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/go.sum') }}
+        key: go-mod-${{ runner.os }}-${{ runner.arch }}-${{ github.job }}-${{ hashFiles('**/go.sum') }}
         restore-keys: |
-          go-mod-${{ runner.os }}-${{ runner.arch }}-
+          go-mod-${{ runner.os }}-${{ runner.arch }}-${{ github.job }}-
 
     - name: Go Tools Cache
       uses: actions/cache@v4
       with:
         path: ${{ steps.go-bin-path.outputs.path }}
-        key: go-tools-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/Makefile') }}
+        key: go-tools-${{ runner.os }}-${{ runner.arch }}-${{ github.job }}-${{ hashFiles('**/Makefile') }}
         restore-keys: |
-          go-tools-${{ runner.os }}-${{ runner.arch }}-
+          go-tools-${{ runner.os }}-${{ runner.arch }}-${{ github.job }}-
 
     - name: Setup Git Private Module
       if: ${{ inputs.gh_token != '' }}


### PR DESCRIPTION
## Summary
- Adds `github.job` to Go module and tools cache keys
- Prevents cache pollution between jobs that download different module subsets

## Problem
Jobs using this action download different subsets of Go modules. Without job isolation in cache keys, a lightweight job (e.g., `database-lint` downloading only `goose`) could save an incomplete cache that other jobs restore, forcing re-downloads.

## Solution
Include `github.job` in cache keys:
```
go-mod-Linux-ARM64-backend-lint-abc123...
go-mod-Linux-ARM64-build-image-abc123...
```

Each job gets its own isolated cache, ensuring complete module sets without cross-contamination.

Made with [Cursor](https://cursor.com)