### PR TITLE
Default go-version-file to go.mod in install-go-with-cache

### DIFF
--- a/actions/install-go-with-cache/action.yml
+++ b/actions/install-go-with-cache/action.yml
@@ -2,11 +2,11 @@ name: "Setup and Cache Go and Configure Private if needed"
 description: "Setup Go with architecture-specific caching for modules and tools"
 inputs:
   go-version:
-    description: "The Go version to download and use. Supports semver spec and ranges. Not used if go-version-file is specified."
-    default: "1.25"
-  go-version-file:
-    description: "Path to the go.mod or go.work file to extract the version from. When set, go-version is ignored."
+    description: "The Go version to download and use. Supports semver spec and ranges. When set, go-version-file is ignored."
     default: ""
+  go-version-file:
+    description: "Path to the go.mod or go.work file to extract the version from. Defaults to go.mod so projects automatically use the version declared in their module."
+    default: "go.mod"
   gh_token:
     description: "GitHub Personal Access Token"
 
@@ -16,8 +16,8 @@ runs:
     - name: Setup Go
       uses: actions/setup-go@v6
       with:
-        go-version: ${{ inputs.go-version-file == '' && inputs.go-version || '' }}
-        go-version-file: ${{ inputs.go-version-file }}
+        go-version: ${{ inputs.go-version }}
+        go-version-file: ${{ inputs.go-version == '' && inputs.go-version-file || '' }}
         cache: false
 
     - name: Detect GOMODCACHE path


### PR DESCRIPTION
## Summary

- Default `go-version-file` to `go.mod` instead of empty, and `go-version` to empty instead of `"1.25"`
- When no inputs are provided, the action now reads the Go version from the project's own `go.mod`
- Explicit `go-version` input still overrides `go-version-file` when provided

## Problem

Workflows using `pull_request_target` run the workflow YAML from the **base branch**, not the PR branch. If the base branch workflow passes no `go-version` input, the old hardcoded default `"1.25"` was used as a semver range — resolving to whatever `1.25.x` was cached on the runner (e.g. `1.25.6`), even when the PR's `go.mod` requires `go >= 1.25.7`.

This caused failures like:
```
go: go.mod requires go >= 1.25.7 (running go 1.25.6; GOTOOLCHAIN=local)
```

Example: [jfrog/jfrog-cli#3373 CI failure](https://github.com/jfrog/jfrog-cli/actions/runs/22402834023/job/64854082677?pr=3373)

## Fix

By defaulting to `go-version-file: go.mod`, the action reads the version from the **checked-out code** (which comes from the PR branch via `ref: ${{ github.event.pull_request.head.sha }}`), not from the workflow YAML. Every Go project has a `go.mod`, so this works universally.

| Usage | Before | After |
|---|---|---|
| No inputs | `go-version: 1.25` (range → cached 1.25.x) | Reads `go.mod` → exact version |
| `go-version: 1.25.7` | Works | Works (overrides file) |
| `go-version-file: go.work` | Works | Works |