### PR TITLE
Bump action dependencies to Node.js 24 compatible versions

### DIFF
--- a/actions/cla/action.yml
+++ b/actions/cla/action.yml
@@ -17,7 +17,7 @@ inputs:
 runs:
   using: 'composite'
   steps:
-    - uses: kaisugi/action-regex-match@v1.0.1
+    - uses: kaisugi/action-regex-match@v1.0.2
       id: sign-or-recheck
       with:
         text: ${{ inputs.event_comment_body }}

--- a/actions/golangci-lint/action.yml
+++ b/actions/golangci-lint/action.yml
@@ -9,7 +9,7 @@ runs:
       run: go mod download
 
     - name: Static Code Analysis
-      uses: golangci/golangci-lint-action@v8
+      uses: golangci/golangci-lint-action@v9
       with:
         skip-cache: true
         args: |

--- a/actions/install-go-with-cache/action.yml
+++ b/actions/install-go-with-cache/action.yml
@@ -48,7 +48,7 @@ runs:
     # download different subsets of modules (e.g., a lint job vs a build job).
     # This ensures each job maintains its own cache without polluting others.
     - name: Go Modules Cache
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: ${{ steps.go-cache-paths.outputs.gomodcache }}
         key: go-mod-${{ runner.os }}-${{ runner.arch }}-${{ github.job }}-${{ hashFiles('**/go.sum') }}
@@ -56,7 +56,7 @@ runs:
           go-mod-${{ runner.os }}-${{ runner.arch }}-${{ github.job }}-
 
     - name: Go Tools Cache
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: ${{ steps.go-bin-path.outputs.path }}
         key: go-tools-${{ runner.os }}-${{ runner.arch }}-${{ github.job }}-${{ hashFiles('**/Makefile') }}

--- a/actions/pr-labels/action.yml
+++ b/actions/pr-labels/action.yml
@@ -23,7 +23,7 @@ runs:
   using: composite
   steps:
     - name: Check if PR has allowed labels
-      uses: actions/github-script@v7
+      uses: actions/github-script@v8
       with:
         script: |
           const { data: pr } = await github.rest.pulls.get({


### PR DESCRIPTION
## Overview

Updates all shared org actions to use Node.js 24 compatible dependency versions, resolving the GitHub Actions deprecation warnings that fire on every workflow run.

Node.js 20 EOL is April 30, 2026. GitHub forces Node.js 24 on June 2, 2026. These bumps are drop-in replacements with no breaking changes for consumers on GitHub-hosted runners.

## Updates

| Action | Dependency | Old | New | Node.js |
|--------|-----------|-----|-----|---------|
| `install-go-with-cache` | `actions/cache` | `@v4` | `@v5` | 20 → 24 |
| `pr-labels` | `actions/github-script` | `@v7` | `@v8` | 20 → 24 |
| `golangci-lint` | `golangci/golangci-lint-action` | `@v8` | `@v9` | 20 → 24 |
| `cla` | `kaisugi/action-regex-match` | `@v1.0.1` | `@v1.0.2` | patch bump |

## Notes

- All updates are backward compatible — no input/output changes
- `actions/cache@v5` uses the new cache backend (v2) with up to 80% faster uploads
- Self-hosted runners need version ≥ 2.327.1 (all GitHub-hosted runners already meet this)
- `contributor-assistant/github-action@v2.6.1` (CLA) has no node24-compatible release yet — left as-is