### PR TITLE
Updated logic for setup of artifactory instance when url is given

### DIFF
--- a/actions/install-local-artifactory/action.yml
+++ b/actions/install-local-artifactory/action.yml
@@ -32,10 +32,15 @@ runs:
       run: |
         if [ -n "${JFROG_URL}" ]; then
           echo "Using external Artifactory at: ${JFROG_URL}"
+          echo "::add-mask::${JFROG_ADMIN_TOKEN}"
           echo "JFROG_TESTS_LOCAL_ACCESS_TOKEN=${JFROG_ADMIN_TOKEN}" >> $GITHUB_ENV
           echo "JFROG_TESTS_URL=${JFROG_URL}" >> $GITHUB_ENV
           echo "JFROG_TESTS_IS_EXTERNAL=true" >> $GITHUB_ENV
         else
+          if [ -z "${RTLIC}" ]; then
+            echo "Error: RTLIC is required when JFROG_URL is not provided."
+            exit 1
+          fi
           go install github.com/jfrog/jfrog-testing-infra/local-rt-setup@${RT_SETUP_VERSION}
           if [ -n "${VERSION}" ]; then
             ~/go/bin/local-rt-setup --rt-version "${VERSION}" --connection-timeout-seconds "${RT_CONNECTION_TIMEOUT_SECONDS}"

--- a/actions/install-local-artifactory/action.yml
+++ b/actions/install-local-artifactory/action.yml
@@ -1,9 +1,9 @@
 name: "Setup Local Artifactory"
-description: "Setup Local Artifactory"
+description: "Setup Local Artifactory or connect to an external JFrog Platform instance"
 inputs:
   RTLIC:
-    description: "Local Artifactory License."
-    required: true
+    description: "Local Artifactory License. Not required when JFROG_URL is provided."
+    required: false
   JFROG_HOME:
     description: "JFrog Home."
     required: false
@@ -18,17 +18,31 @@ inputs:
     description: "Connection timeout for the local Artifactory to be up."
     required: false
     default: "1200"
+  JFROG_URL:
+    description: "External JFrog Platform URL. If provided, skip local Artifactory install and use this instance instead."
+    required: false
+  JFROG_ADMIN_TOKEN:
+    description: "Admin token for external JFrog Platform. Required when JFROG_URL is set."
+    required: false
 
 runs:
   using: "composite"
   steps:
-    - name: Install Local Artifactory
+    - name: Setup Artifactory
       run: |
-        go install github.com/jfrog/jfrog-testing-infra/local-rt-setup@${RT_SETUP_VERSION}
-        if [ -n "${VERSION}" ]; then
-          ~/go/bin/local-rt-setup --rt-version "${VERSION}" --connection-timeout-seconds "${RT_CONNECTION_TIMEOUT_SECONDS}"
+        if [ -n "${JFROG_URL}" ]; then
+          echo "Using external Artifactory at: ${JFROG_URL}"
+          echo "JFROG_TESTS_LOCAL_ACCESS_TOKEN=${JFROG_ADMIN_TOKEN}" >> $GITHUB_ENV
+          echo "JFROG_TESTS_URL=${JFROG_URL}" >> $GITHUB_ENV
+          echo "JFROG_TESTS_IS_EXTERNAL=true" >> $GITHUB_ENV
         else
-          ~/go/bin/local-rt-setup --connection-timeout-seconds "${RT_CONNECTION_TIMEOUT_SECONDS}"
+          go install github.com/jfrog/jfrog-testing-infra/local-rt-setup@${RT_SETUP_VERSION}
+          if [ -n "${VERSION}" ]; then
+            ~/go/bin/local-rt-setup --rt-version "${VERSION}" --connection-timeout-seconds "${RT_CONNECTION_TIMEOUT_SECONDS}"
+          else
+            ~/go/bin/local-rt-setup --connection-timeout-seconds "${RT_CONNECTION_TIMEOUT_SECONDS}"
+          fi
+          echo "JFROG_TESTS_URL=http://127.0.0.1:8082" >> $GITHUB_ENV
         fi
       shell: bash
       env:
@@ -37,3 +51,5 @@ runs:
         VERSION: ${{ inputs.VERSION }}
         RT_SETUP_VERSION: ${{ inputs.RT_SETUP_VERSION }}
         RT_CONNECTION_TIMEOUT_SECONDS: ${{ inputs.RT_CONNECTION_TIMEOUT_SECONDS }}
+        JFROG_URL: ${{ inputs.JFROG_URL }}
+        JFROG_ADMIN_TOKEN: ${{ inputs.JFROG_ADMIN_TOKEN }}


### PR DESCRIPTION
What: Updated logic for setup of artifactory instance when url is given
Why: We have a need of setting up artifactory instance in many tests, but not with local instance.