### PR TITLE
RTECO-1299 - Mask local Artifactory admin token in CI logs

### DIFF
--- a/actions/install-local-artifactory/action.yml
+++ b/actions/install-local-artifactory/action.yml
@@ -58,3 +58,14 @@ runs:
         RT_CONNECTION_TIMEOUT_SECONDS: ${{ inputs.RT_CONNECTION_TIMEOUT_SECONDS }}
         JFROG_URL: ${{ inputs.JFROG_URL }}
         JFROG_ADMIN_TOKEN: ${{ inputs.JFROG_ADMIN_TOKEN }}
+
+    - name: Mask Artifactory admin token in CI logs
+      # Local-install mode writes JFROG_TESTS_LOCAL_ACCESS_TOKEN to $GITHUB_ENV
+      # via local-rt-setup, which isn't auto-masked. Register it with the
+      # runner's secret-masker so subsequent log lines (including rendered
+      # `run:` headers that interpolate the value) redact it as ***.
+      shell: bash
+      run: |
+        if [ -n "${JFROG_TESTS_LOCAL_ACCESS_TOKEN:-}" ]; then
+          echo "::add-mask::${JFROG_TESTS_LOCAL_ACCESS_TOKEN}"
+        fi


### PR DESCRIPTION
install-local-artifactory exports JFROG_TESTS_LOCAL_ACCESS_TOKEN via $GITHUB_ENV in local-install mode, but never registers it with the runner's secret-masker. Any consumer step that interpolates --jfrog.adminToken=${{ env.JFROG_TESTS_LOCAL_ACCESS_TOKEN }} prints the token in plain text in the rendered Run step header (seen in jfrog-cli-artifactory PR #458, artifactory windows job).

Add a follow-up step that reads the env var (now visible since $GITHUB_ENV writes propagate to the next step) and calls ::add-mask::. Every consumer of the action — jfrog-cli, jfrog-cli-core, jfrog-cli-security, jfrog-cli-artifactory, build-info-go — now gets the token redacted as *** automatically, with zero workflow changes required.

The external-JFrog mode already masks on line 35, so no behavior change there.